### PR TITLE
Update C# API File Naming Convention

### DIFF
--- a/src/editor/generate_csharp_bindings.cpp
+++ b/src/editor/generate_csharp_bindings.cpp
@@ -30,6 +30,13 @@ bool GenerateCSharpBindingsPlugin::is_need_to_update() {
 	if (!ClassDB::class_exists("CSharpScript"))
 		return false;
 
+	// Old file name
+	const String old_api_path = output_directory.path_join("DebugDrawGeneratedAPI.cs");
+	if (FileAccess::file_exists(old_api_path)) {
+		return true;
+	}
+	
+	
 	const String api_path = output_directory.path_join(api_file_name);
 	if (FileAccess::file_exists(api_path)) {
 		auto file = FileAccess::open(api_path, FileAccess::READ);
@@ -60,6 +67,14 @@ void GenerateCSharpBindingsPlugin::generate() {
 			dir->remove(f);
 		}
 	}
+
+	// Delete the file with the older naming convention
+	const String old_api_path = output_directory.path_join("DebugDrawGeneratedAPI.cs");
+	if (FileAccess::file_exists(old_api_path)) {
+		PRINT("Attempt to delete API file with older naming convention: " + out_path);
+		ERR_FAIL_COND(dir->remove(old_api_path) != Error::OK);
+	}
+	
 
 	// First, delete the old file to check for locks
 	if (FileAccess::file_exists(out_path)) {

--- a/src/editor/generate_csharp_bindings.h
+++ b/src/editor/generate_csharp_bindings.h
@@ -80,7 +80,7 @@ class GenerateCSharpBindingsPlugin {
 	};
 
 	String output_directory = "res://addons/debug_draw_3d/gen/csharp";
-	String api_file_name = "DebugDrawGeneratedAPI.cs";
+	String api_file_name = "DebugDrawGeneratedAPI.generated.cs";
 	String log_file_name = "log.txt";
 	String indent_template = "    ";
 	String indent;


### PR DESCRIPTION
This PR updates the C# binding file naming convention to include a .generated suffix. It also removes files using the older naming convention to avoid errors on the C# side when both exist (e.g. during upgrades).

Adding the .generated suffix hides irrelevant warnings in the IDE and during project builds. This is so custom user csproj settings for warnings and added analyzers don't flag issues with the generated files, 