### PR TITLE
draw_text / Label3D fixed size flag in scoped config

### DIFF
--- a/src/3d/config_scope_3d.cpp
+++ b/src/3d/config_scope_3d.cpp
@@ -39,6 +39,9 @@ void DebugDraw3DScopeConfig::_bind_methods() {
 
 	REG_METHOD(set_text_font, "value");
 	REG_METHOD(get_text_font);
+
+	REG_METHOD(set_text_fixed_size, "value");
+	REG_METHOD(get_text_fixed_size);
 #undef REG_CLASS_NAME
 }
 
@@ -129,6 +132,15 @@ Ref<Font> DebugDraw3DScopeConfig::get_text_font() const {
 	return data->text_font;
 }
 
+Ref<DebugDraw3DScopeConfig> DebugDraw3DScopeConfig::set_text_fixed_size(bool value) const {
+	data->text_fixed_size = value;
+	return Ref<DebugDraw3DScopeConfig>(this);
+}
+
+bool DebugDraw3DScopeConfig::get_text_fixed_size() const {
+	return data->text_fixed_size;
+}
+
 Ref<DebugDraw3DScopeConfig> DebugDraw3DScopeConfig::set_viewport(Viewport *_value) const {
 	data->dcd.viewport = _value;
 	data->dcd.viewport_id = _value ? _value->get_instance_id() : 0;
@@ -176,6 +188,7 @@ DebugDraw3DScopeConfig::Data::Data() :
 		transform(Transform3D()),
 		text_outline_color(Color(0, 0, 0, 1)),
 		text_outline_size(12),
+		text_fixed_size(false),
 		text_font(nullptr),
 		dcd({}),
 		hd_sphere(false),
@@ -194,6 +207,7 @@ DebugDraw3DScopeConfig::Data::Data(const Data *p_parent) :
 		text_outline_color(p_parent->text_outline_color),
 		text_outline_color_hash(p_parent->text_outline_color_hash),
 		text_outline_size(p_parent->text_outline_size),
+		text_fixed_size(p_parent->text_fixed_size),
 		text_font(p_parent->text_font),
 		dcd(p_parent->dcd),
 		hd_sphere(p_parent->hd_sphere),

--- a/src/3d/config_scope_3d.h
+++ b/src/3d/config_scope_3d.h
@@ -88,6 +88,7 @@ public:
 		Color text_outline_color;
 		uint32_t text_outline_color_hash;
 		int32_t text_outline_size;
+		bool text_fixed_size;
 		Ref<Font> text_font;
 		DebugContainerDependent dcd;
 		bool hd_sphere;
@@ -162,6 +163,17 @@ public:
 	 */
 	Ref<DebugDraw3DScopeConfig> set_text_outline_size(int32_t _value) const;
 	int32_t get_text_outline_size() const;
+
+	/**
+	 * Makes the text in DebugDraw3D.draw_text the same size regardless of distance.
+	 *
+	 * ![](docs/images/classes/DrawTextFixedSize.webp)
+	 *
+	 * @warning
+	 * Frequent unsystematic changes to this property can lead to significant performance degradation.
+	 */
+	Ref<DebugDraw3DScopeConfig> set_text_fixed_size(bool _value) const;
+	bool get_text_fixed_size() const;
 
 	/**
 	 * Set the font of the text in DebugDraw3D.draw_text.

--- a/src/3d/debug_draw_3d.h
+++ b/src/3d/debug_draw_3d.h
@@ -755,7 +755,8 @@ public:
 	 *
 	 * @note
 	 * Outline can be changed using DebugDraw3DScopeConfig.set_text_outline_color and DebugDraw3DScopeConfig.set_text_outline_size.
-	 * And the font can be changed using DebugDraw3DScopeConfig.set_text_font.
+	 * The font can be changed using DebugDraw3DScopeConfig.set_text_font.
+	 * The text can be made to stay the same size regardless of distance using DebugDraw3DScopeConfig.set_text_fixed_size.
 	 *
 	 * ![](docs/images/classes/DrawText.webp)
 	 *

--- a/src/3d/nodes_container.cpp
+++ b/src/3d/nodes_container.cpp
@@ -322,7 +322,17 @@ void NodesContainer::add_or_update_text(const DebugDraw3DScopeConfig::Data *p_cf
 	opts_hash = hash_murmur3_one_32((uint32_t)p_cfg->text_fixed_size, opts_hash);
 
 	uint32_t text_hash = text.hash();
-
+	real_t pixel_size = 0.005f; // godot default
+	if (p_cfg->text_fixed_size) {
+		Vector2 viewport_size = p_cfg->dcd.viewport ? p_cfg->dcd.viewport->get_visible_rect().size : Vector2(1.f, 1.f);
+		Camera3D *cam = p_cfg->dcd.viewport ? p_cfg->dcd.viewport->get_camera_3d() : nullptr;
+		if (cam) {
+			bool keep_height = cam->get_keep_aspect_mode();
+			real_t aspect_ratio = 1.0f / (keep_height ? viewport_size.y : viewport_size.x);
+			real_t fov = (cam->get_projection() == godot::Camera3D::ProjectionType::PROJECTION_PERSPECTIVE ? cam->get_fov() : 90.0f);
+			pixel_size = godot::Math::atan(fov * 0.5f) * aspect_ratio;
+		}
+	}
 	// if called from the main thread, just add/update
 	if (auto *os = OS::get_singleton(); os->get_thread_caller_id() == os->get_main_thread_id()) {
 		auto *lblit = text_pools[(int)(Engine::get_singleton()->is_in_physics_frame() ? ProcessType::PHYSICS_PROCESS : ProcessType::PROCESS)].get(opts_hash, text_hash);
@@ -343,6 +353,7 @@ void NodesContainer::add_or_update_text(const DebugDraw3DScopeConfig::Data *p_cf
 		lbl3d->set_outline_modulate(p_cfg->text_outline_color);
 		lbl3d->set_outline_size(p_cfg->text_outline_size);
 		lbl3d->set_draw_flag(Label3D::DrawFlags::FLAG_FIXED_SIZE, p_cfg->text_fixed_size);
+		lbl3d->set_pixel_size(pixel_size);
 	} else {
 		// wait for the end of the frame to display anything from the user thread
 		deferred_text_queue.emplace(
@@ -356,7 +367,8 @@ void NodesContainer::add_or_update_text(const DebugDraw3DScopeConfig::Data *p_cf
 				/* Color color */ color,
 				/* Color outline_color */ p_cfg->text_outline_color,
 				/* int outline_size */ p_cfg->text_outline_size,
-				/* bool fixed_size */ p_cfg->text_fixed_size)
+				/* bool fixed_size */ p_cfg->text_fixed_size,
+				/* real_t pixel_size */ pixel_size);
 	}
 }
 
@@ -389,6 +401,7 @@ void NodesContainer::_render_queued_nodes() {
 			lbl3d->set_outline_modulate(i.outline_color);
 			lbl3d->set_outline_size(i.outline_size);
 			lbl3d->set_draw_flag(Label3D::DrawFlags::FLAG_FIXED_SIZE, i.fixed_size);
+			lbl3d->set_pixel_size(i.pixel_size);
 		}
 
 		deferred_text_queue.pop();

--- a/src/3d/nodes_container.cpp
+++ b/src/3d/nodes_container.cpp
@@ -319,6 +319,7 @@ void NodesContainer::add_or_update_text(const DebugDraw3DScopeConfig::Data *p_cf
 	opts_hash = hash_murmur3_one_float(color.a, opts_hash);
 	opts_hash = hash_murmur3_one_32(p_cfg->text_outline_color_hash, opts_hash);
 	opts_hash = hash_murmur3_one_32((uint32_t)p_cfg->text_outline_size, opts_hash);
+	opts_hash = hash_murmur3_one_32((uint32_t)p_cfg->text_fixed_size, opts_hash);
 
 	uint32_t text_hash = text.hash();
 
@@ -341,6 +342,7 @@ void NodesContainer::add_or_update_text(const DebugDraw3DScopeConfig::Data *p_cf
 		lbl3d->set_modulate(color);
 		lbl3d->set_outline_modulate(p_cfg->text_outline_color);
 		lbl3d->set_outline_size(p_cfg->text_outline_size);
+		lbl3d->set_draw_flag(Label3D::DrawFlags::FLAG_FIXED_SIZE, p_cfg->text_fixed_size);
 	} else {
 		// wait for the end of the frame to display anything from the user thread
 		deferred_text_queue.emplace(
@@ -353,7 +355,8 @@ void NodesContainer::add_or_update_text(const DebugDraw3DScopeConfig::Data *p_cf
 				/* int font_size */ size,
 				/* Color color */ color,
 				/* Color outline_color */ p_cfg->text_outline_color,
-				/* int outline_size */ p_cfg->text_outline_size);
+				/* int outline_size */ p_cfg->text_outline_size,
+				/* bool fixed_size */ p_cfg->text_fixed_size)
 	}
 }
 
@@ -385,6 +388,7 @@ void NodesContainer::_render_queued_nodes() {
 			lbl3d->set_modulate(i.color);
 			lbl3d->set_outline_modulate(i.outline_color);
 			lbl3d->set_outline_size(i.outline_size);
+			lbl3d->set_draw_flag(Label3D::DrawFlags::FLAG_FIXED_SIZE, i.fixed_size);
 		}
 
 		deferred_text_queue.pop();

--- a/src/3d/nodes_container.h
+++ b/src/3d/nodes_container.h
@@ -127,6 +127,7 @@ class NodesContainer {
 		Color outline_color;
 		int outline_size;
 		bool fixed_size;
+		real_t pixel_size;
 
 		TextNodeDeferredQueueItem(
 				const real_t &duration,
@@ -139,7 +140,8 @@ class NodesContainer {
 				const Color &color,
 				const Color &outline_color,
 				const int &outline_size,
-				const bool &fixed_size) :
+				const bool &fixed_size,
+				const real_t &pixel_size) :
 
 				duration(duration),
 				opts_hash(opts_hash),
@@ -151,7 +153,8 @@ class NodesContainer {
 				color(color),
 				outline_color(outline_color),
 				outline_size(outline_size),
-				fixed_size(fixed_size) {}
+				fixed_size(fixed_size),
+				pixel_size(pixel_size) {}
 	};
 	std::queue<TextNodeDeferredQueueItem> deferred_text_queue;
 	void _render_queued_nodes();

--- a/src/3d/nodes_container.h
+++ b/src/3d/nodes_container.h
@@ -126,6 +126,7 @@ class NodesContainer {
 		Color color;
 		Color outline_color;
 		int outline_size;
+		bool fixed_size;
 
 		TextNodeDeferredQueueItem(
 				const real_t &duration,
@@ -137,7 +138,8 @@ class NodesContainer {
 				const int &font_size,
 				const Color &color,
 				const Color &outline_color,
-				const int &outline_size) :
+				const int &outline_size,
+				const bool &fixed_size) :
 
 				duration(duration),
 				opts_hash(opts_hash),
@@ -148,7 +150,8 @@ class NodesContainer {
 				font_size(font_size),
 				color(color),
 				outline_color(outline_color),
-				outline_size(outline_size) {}
+				outline_size(outline_size),
+				fixed_size(fixed_size) {}
 	};
 	std::queue<TextNodeDeferredQueueItem> deferred_text_queue;
 	void _render_queued_nodes();


### PR DESCRIPTION
basic code that allows to turn on `fixed_size` on the label3d of a draw_text command with a scoped config flag.

second commit is attempting to make the `pixel_size` of the label be 1:1 with a 2d label with the same font and size. that part's a work in progress so I am making this PR a draft, and i also split into two commits so that you could cherry pick just the fixed size code.