### PR TITLE
Fix incorrect ProjectSettings usage

### DIFF
--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -155,8 +155,6 @@ static String get_file_name_in_repository(const String &name) {
 		Dictionary info;                           \
 		info["name"] = path;                       \
 		info["type"] = type;                       \
-		/* Does not work in the ProjectSettings */ \
-		info["usage"] = PROPERTY_USAGE_READ_ONLY;  \
 		PS()->add_property_info(info);             \
 		PS()->set_initial_value(path, def);        \
 	}


### PR DESCRIPTION
```ProjectSettings.add_property_info()``` prints an error in 4.5 if the dictionary passed has a "usage" key because it doesn't do anything. Aside from removing the error this pr does not change any behaviour.

Closes https://github.com/DmitriySalnikov/godot_debug_draw_3d/issues/83